### PR TITLE
fix: fixed rcs channel to point to v2 of ZenviaAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenvia/sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "Henrique Magarotto <henrique.magarotto@zenvia.com> (https://github.com/hmagarotto)",
     "Rafael Souza <rafael.souza@zenvia.com> (https://github.com/rafael-org)",
     "Jhonnanthn Balsas <jhonnanthn.balsas@zenvia.com> (https://github.com/jhonnanthn)",
-    "Rafael Pimenta <rafael.pimenta@zenvia.com> (https://github.com/rafaelgpimenta)"
+    "Rafael Pimenta <rafael.pimenta@zenvia.com> (https://github.com/rafaelgpimenta)",
+    "Victor Park <victor.park@zenvia.com> (https://github.com/victorshp)"
   ],
   "scripts": {
     "test": "nyc --all mocha",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenvia/sdk",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/channels/abstract-channel.ts
+++ b/src/lib/channels/abstract-channel.ts
@@ -55,13 +55,7 @@ export abstract class AbstractChannel implements IChannel {
    * @returns A promise that resolves to an [[IMessage]] object.
    */
   private async request(message: IMessageRequest): Promise<IMessage> {
-    let path = '';
-    const v2Channels = ['rcs'];
-    if (v2Channels.includes(this.channel)) {
-      path = `/v2/channels/${this.channel}/messages`;
-    } else {
-      path = `/v1/channels/${this.channel}/messages`;
-    }
+    const path = `/v2/channels/${this.channel}/messages`;
     return request.post(this.token, path, message, this.logger);
   }
 

--- a/src/lib/channels/abstract-channel.ts
+++ b/src/lib/channels/abstract-channel.ts
@@ -1,4 +1,4 @@
-import { IChannel, IMessageRequest, IMessage, Channel, IContent, ILoggerInstance } from '../../types';
+import { IChannel, IMessageRequest, IMessage, Channel, IContent, ILoggerInstance, RcsChannel } from '../../types';
 import { Logger } from '../../utils/logger';
 import * as request from '../../utils/request';
 
@@ -55,7 +55,13 @@ export abstract class AbstractChannel implements IChannel {
    * @returns A promise that resolves to an [[IMessage]] object.
    */
   private async request(message: IMessageRequest): Promise<IMessage> {
-    const path = `/v1/channels/${this.channel}/messages`;
+    let path = '';
+    const v2Channels = ['rcs'];
+    if (v2Channels.includes(this.channel)) {
+      path = `/v2/channels/${this.channel}/messages`;
+    } else {
+      path = `/v1/channels/${this.channel}/messages`;
+    }
     return request.post(this.token, path, message, this.logger);
   }
 

--- a/src/lib/channels/abstract-channel.ts
+++ b/src/lib/channels/abstract-channel.ts
@@ -1,4 +1,4 @@
-import { IChannel, IMessageRequest, IMessage, Channel, IContent, ILoggerInstance, RcsChannel } from '../../types';
+import { IChannel, IMessageRequest, IMessage, Channel, IContent, ILoggerInstance } from '../../types';
 import { Logger } from '../../utils/logger';
 import * as request from '../../utils/request';
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -98,7 +98,7 @@ export class Client {
    * @returns A promise that resolves to an array of [[ISubscription]] objects.
    */
   async listSubscriptions(): Promise<ISubscription[]> {
-    const path = '/v1/subscriptions';
+    const path = '/v2/subscriptions';
     return request.get(this.token, path, this.logger);
   }
 
@@ -109,7 +109,7 @@ export class Client {
    * @returns A promise that resolves to an [[ISubscription]] object.
    */
   async createSubscription(subscription: ISubscription): Promise<ISubscription> {
-    const path = '/v1/subscriptions';
+    const path = '/v2/subscriptions';
     return request.post(this.token, path, subscription, this.logger);
   }
 
@@ -120,7 +120,7 @@ export class Client {
    * @returns A promise that resolves to an [[ISubscription]] object.
    */
   async getSubscription(id: string): Promise<ISubscription> {
-    const path = `/v1/subscriptions/${id}`;
+    const path = `/v2/subscriptions/${id}`;
     return request.get(this.token, path, this.logger);
   }
 
@@ -132,7 +132,7 @@ export class Client {
    * @returns A promise that resolves to an [[ISubscription]] object.
    */
   async updateSubscription(id: string, subscription: IPartialSubscription): Promise<ISubscription> {
-    const path = `/v1/subscriptions/${id}`;
+    const path = `/v2/subscriptions/${id}`;
     return request.patch(this.token, path, subscription, this.logger);
   }
 
@@ -143,7 +143,7 @@ export class Client {
    * @returns A promise that resolves to an [[ISubscription]] object.
    */
   async deleteSubscription(id: string): Promise<void> {
-    const path = `/v1/subscriptions/${id}`;
+    const path = `/v2/subscriptions/${id}`;
     return request.del(this.token, path, this.logger);
   }
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -153,7 +153,7 @@ export class Client {
    * @returns A promise that resolves to an array of [[ITemplate]] objects.
    */
   async listTemplates(): Promise<ITemplate[]> {
-    const path = '/v1/templates';
+    const path = '/v2/templates';
     return request.get(this.token, path, this.logger)
     .then((templates) => {
       templates.forEach((template) => {
@@ -172,7 +172,7 @@ export class Client {
    * @returns A promise that resolves to an [[ITemplate]] object.
    */
   async getTemplate(id: string): Promise<ITemplate> {
-    const path = `/v1/templates/${id}`;
+    const path = `/v2/templates/${id}`;
     return request.get(this.token, path, this.logger)
     .then((template: ITemplate) => {
       template.channels.forEach((channel) => {
@@ -189,7 +189,7 @@ export class Client {
    * @returns A promise that resolves to an [[ITemplate]] object.
    */
   async createTemplate(template: ITemplate): Promise<ITemplate> {
-    const path = '/v1/templates';
+    const path = '/v2/templates';
     return request.post(this.token, path, template, this.logger);
   }
 
@@ -201,7 +201,7 @@ export class Client {
    * @returns A promise that resolves to an [[ITemplate]] object.
    */
   async updateTemplate(id: string, template: IPartialTemplate): Promise<ITemplate> {
-    const path = `/v1/templates/${id}`;
+    const path = `/v2/templates/${id}`;
     return request.patch(this.token, path, template, this.logger);
   }
 
@@ -212,7 +212,7 @@ export class Client {
    * @returns A promise that resolves to an [[ITemplate]] object.
    */
   async deleteTemplate(id: string): Promise<void> {
-    const path = `/v1/templates/${id}`;
+    const path = `/v2/templates/${id}`;
     return request.del(this.token, path, this.logger);
   }
 

--- a/src/lib/reports/abstract.ts
+++ b/src/lib/reports/abstract.ts
@@ -31,7 +31,7 @@ export class AbstractReport<E extends IReportEntry, F extends IReportFilters> {
       properties.push(`${key}=${value}`);
     }
 
-    const path = `/v1/reports/${this.reportName}/entries`;
+    const path = `/v2/reports/${this.reportName}/entries`;
     let queryParameters = '';
     if (properties.length > 0) {
       queryParameters = `?${properties.join('&')}`;

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -22,7 +22,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/sms/messages', expectedMessage)
+        .post('/v2/channels/sms/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -50,7 +50,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/sms/messages', expectedMessage)
+        .post('/v2/channels/sms/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -251,7 +251,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/facebook/messages', expectedMessage)
+        .post('/v2/channels/facebook/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -277,7 +277,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/facebook/messages', expectedMessage)
+        .post('/v2/channels/facebook/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -357,7 +357,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/whatsapp/messages', expectedMessage)
+        .post('/v2/channels/whatsapp/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -383,7 +383,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/whatsapp/messages', expectedMessage)
+        .post('/v2/channels/whatsapp/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -413,7 +413,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/whatsapp/messages', expectedMessage)
+        .post('/v2/channels/whatsapp/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -442,7 +442,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/whatsapp/messages', expectedMessage)
+        .post('/v2/channels/whatsapp/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -478,7 +478,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/whatsapp/messages', expectedMessage)
+        .post('/v2/channels/whatsapp/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -522,7 +522,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/whatsapp/messages', expectedMessage)
+        .post('/v2/channels/whatsapp/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -547,7 +547,7 @@ describe('Client', () => {
         };
 
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/whatsapp/messages')
+        .post('/v2/channels/whatsapp/messages')
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(400, errorResponse);
 

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -1214,7 +1214,7 @@ describe('Client', () => {
         },
       }];
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/reports/flow/entries?startDate=2020-01-10')
+      .get('/v2/reports/flow/entries?startDate=2020-01-10')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedFlow);
 
@@ -1242,7 +1242,7 @@ describe('Client', () => {
         },
       ];
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/reports/message/entries?startDate=2020-01-10&endDate=2020-01-11')
+      .get('/v2/reports/message/entries?startDate=2020-01-10&endDate=2020-01-11')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedMessage);
 
@@ -1259,7 +1259,7 @@ describe('Client', () => {
       };
 
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/reports/flow/entries')
+      .get('/v2/reports/flow/entries')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(400, errorResponse);
 
@@ -1279,7 +1279,7 @@ describe('Client', () => {
       };
 
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/reports/message/entries')
+      .get('/v2/reports/message/entries')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(400, errorResponse);
 
@@ -1409,7 +1409,7 @@ describe('Client', () => {
         updatedAt: '2020-06-22T20:35:05.491Z',
       }];
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/templates')
+      .get('/v2/templates')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, requestTemplates);
 
@@ -1481,7 +1481,7 @@ describe('Client', () => {
         updatedAt: '2020-06-22T20:35:05.491Z',
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/templates/SOME_TEMPLATE_ID')
+      .get('/v2/templates/SOME_TEMPLATE_ID')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, requestTemplates);
 
@@ -1514,7 +1514,7 @@ describe('Client', () => {
         },
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .post('/v1/templates', expectedTemplate)
+      .post('/v2/templates', expectedTemplate)
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedTemplate);
 
@@ -1562,7 +1562,7 @@ describe('Client', () => {
         },
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .patch('/v1/templates/SOME_TEMPLATE_ID', {
+      .patch('/v2/templates/SOME_TEMPLATE_ID', {
         notificationEmail: 'test@zenvia.com',
         components: {
           body: {
@@ -1590,7 +1590,7 @@ describe('Client', () => {
 
     it('should delete template', async () => {
       const zenviaNock = nock('https://api.zenvia.com')
-      .delete('/v1/templates/SOME_TEMPLATE_ID')
+      .delete('/v2/templates/SOME_TEMPLATE_ID')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(204);
 
@@ -1626,7 +1626,7 @@ describe('Client', () => {
         message: 'Request has one or more errors\n  In body\n    For Content-Type application/json\n      Invalid value\n        One or more required properties missing: name',
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .post('/v1/templates', expectedTemplate)
+      .post('/v2/templates', expectedTemplate)
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(400, errorResponse);
 

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -130,7 +130,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/rcs/messages', expectedMessage)
+        .post('/v2/channels/rcs/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -158,7 +158,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/rcs/messages', expectedMessage)
+        .post('/v2/channels/rcs/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 
@@ -184,7 +184,7 @@ describe('Client', () => {
           ],
         };
         const zenviaNock = nock('https://api.zenvia.com')
-        .post('/v1/channels/rcs/messages', expectedMessage)
+        .post('/v2/channels/rcs/messages', expectedMessage)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
         .reply(200, expectedMessage);
 

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -1036,7 +1036,7 @@ describe('Client', () => {
         status: 'ACTIVE',
       }];
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/subscriptions')
+      .get('/v2/subscriptions')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedSubscription);
 
@@ -1058,7 +1058,7 @@ describe('Client', () => {
         status: 'ACTIVE',
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .post('/v1/subscriptions', expectedSubscription)
+      .post('/v2/subscriptions', expectedSubscription)
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedSubscription);
 
@@ -1082,7 +1082,7 @@ describe('Client', () => {
         status: 'ACTIVE',
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .post('/v1/subscriptions', expectedSubscription)
+      .post('/v2/subscriptions', expectedSubscription)
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedSubscription);
 
@@ -1105,7 +1105,7 @@ describe('Client', () => {
         status: 'ACTIVE',
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .post('/v1/subscriptions', expectedSubscription)
+      .post('/v2/subscriptions', expectedSubscription)
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedSubscription);
 
@@ -1128,7 +1128,7 @@ describe('Client', () => {
         status: 'INACTIVE',
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .post('/v1/subscriptions', expectedSubscription)
+      .post('/v2/subscriptions', expectedSubscription)
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedSubscription);
 
@@ -1151,7 +1151,7 @@ describe('Client', () => {
         status: 'INACTIVE',
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/subscriptions/SOME_SUBSCRIPTION_ID')
+      .get('/v2/subscriptions/SOME_SUBSCRIPTION_ID')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedSubscription);
 
@@ -1173,7 +1173,7 @@ describe('Client', () => {
         status: 'INACTIVE',
       };
       const zenviaNock = nock('https://api.zenvia.com')
-      .patch('/v1/subscriptions/SOME_SUBSCRIPTION_ID', { status: 'INACTIVE' })
+      .patch('/v2/subscriptions/SOME_SUBSCRIPTION_ID', { status: 'INACTIVE' })
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(200, expectedSubscription);
 
@@ -1185,7 +1185,7 @@ describe('Client', () => {
 
     it('should delete subscription', async () => {
       const zenviaNock = nock('https://api.zenvia.com')
-      .delete('/v1/subscriptions/SOME_SUBSCRIPTION_ID')
+      .delete('/v2/subscriptions/SOME_SUBSCRIPTION_ID')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(204);
 
@@ -1313,7 +1313,7 @@ describe('Client', () => {
       };
 
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/subscriptions')
+      .get('/v2/subscriptions')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .reply(400, errorResponse);
 
@@ -1329,7 +1329,7 @@ describe('Client', () => {
 
     it('should handle technical error', async () => {
       const zenviaNock = nock('https://api.zenvia.com')
-      .get('/v1/subscriptions')
+      .get('/v2/subscriptions')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .replyWithError('getaddrinfo ENOTFOUND api.zenvia.com');
 

--- a/test/lib/webhook.spec.ts
+++ b/test/lib/webhook.spec.ts
@@ -211,11 +211,11 @@ describe('Webhook', () => {
     webhook.init();
 
     nock('https://api.zenvia.com')
-      .get('/v1/subscriptions')
+      .get('/v2/subscriptions')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .times(1)
       .reply(200)
-      .post('/v1/subscriptions', {
+      .post('/v2/subscriptions', {
         eventType: 'MESSAGE',
         webhook: {
           url: 'http://localhost:3000',
@@ -228,7 +228,7 @@ describe('Webhook', () => {
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .times(1)
       .reply(200)
-      .post('/v1/subscriptions', {
+      .post('/v2/subscriptions', {
         eventType: 'MESSAGE_STATUS',
         webhook: {
           url: 'http://localhost:3000',
@@ -302,7 +302,7 @@ describe('Webhook', () => {
     });
 
     const scope = nock('https://api.zenvia.com')
-      .post('/v1/subscriptions', {
+      .post('/v2/subscriptions', {
         eventType: 'MESSAGE',
         webhook: {
           url: 'http://localhost:3000',
@@ -316,7 +316,7 @@ describe('Webhook', () => {
       .matchHeader('X-API-Token', 'SOME_TOKEN')
       .times(1)
       .reply(409)
-      .post('/v1/subscriptions', {
+      .post('/v2/subscriptions', {
         eventType: 'MESSAGE_STATUS',
         webhook: {
           url: 'http://localhost:3000',


### PR DESCRIPTION
**Jira Link** => https://zenvia.atlassian.net/browse/CON-205?atlOrigin=eyJpIjoiMjZkODcwNTc0MTExNGM5ZjgwODRkMTU1NmQ1MjE0OTQiLCJwIjoiaiJ9**

**Problem**
All channels were sending message through v1 using this SDK written in node (subscriptions/webhooks too).

**Diagnostic**
Channels and subscriptions (webhooks) needed to be fixed to point to v2 path of Zenvia's API, not V1.

**Implementation**

- All channels and subscriptions points to v2
- Tests adjusted to the above implementation
- v2.0.0 tag added through Git
- PackageJSON from 1.5.0 to 2.0.0