### PR TITLE
getTemplate and listTemplates functions fixed

### DIFF
--- a/examples/template-get.js
+++ b/examples/template-get.js
@@ -8,9 +8,9 @@
 // const { Client } = require('@zenvia/sdk');
 const { Client } = require('../dist');
 
-const client = new Client(process.env.ZENVIA_API_TOKEN);
+const client = new Client('GKkj0dSHDN60yLdkZzVyj4-osKlMQXQj-5d4');
 
-client.getTemplate('template-identifier')
+client.getTemplate('eb5f5a45-c4f2-4086-8f41-6cc423d4fac8')
 .then(response => {
   console.log('Response:', response);
 })

--- a/examples/template-list.js
+++ b/examples/template-list.js
@@ -7,7 +7,7 @@
 
 const { Client } = require('../dist');
 
-const client = new Client(process.env.ZENVIA_API_TOKEN);
+const client = new Client('GKkj0dSHDN60yLdkZzVyj4-osKlMQXQj-5d4');
 
 client.listTemplates()
 .then(response => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenvia/sdk",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -158,11 +158,6 @@ export class Client {
     const path = '/v2/templates';
     return request.get(this.token, path, this.logger)
     .then((templates) => {
-      templates.forEach((template) => {
-        template.channels.forEach((channel) => {
-          (channel.type as any) = channel.type.toLowerCase();
-        });
-      });
       return templates;
     });
   }
@@ -177,9 +172,6 @@ export class Client {
     const path = `/v2/templates/${id}`;
     return request.get(this.token, path, this.logger)
     .then((template: ITemplate) => {
-      template.channels.forEach((channel) => {
-        (channel.type as any) = channel.type.toLowerCase();
-      });
       return template;
     });
   }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -156,10 +156,7 @@ export class Client {
    */
   async listTemplates(): Promise<ITemplate[]> {
     const path = '/v2/templates';
-    return request.get(this.token, path, this.logger)
-    .then((templates) => {
-      return templates;
-    });
+    return request.get(this.token, path, this.logger);
   }
 
   /**
@@ -170,10 +167,7 @@ export class Client {
    */
   async getTemplate(id: string): Promise<ITemplate> {
     const path = `/v2/templates/${id}`;
-    return request.get(this.token, path, this.logger)
-    .then((template: ITemplate) => {
-      return template;
-    });
+    return request.get(this.token, path, this.logger);
   }
 
   /**

--- a/src/types/zenvia.ts
+++ b/src/types/zenvia.ts
@@ -332,7 +332,9 @@ export interface IComponents {
 export interface IButtonsItems {
   type: string;
   text: string;
-  url: string;
+  url?: string;
+  phoneNumber?: string;
+  payload?: string;
 }
 
 export interface IChannels {

--- a/src/types/zenvia.ts
+++ b/src/types/zenvia.ts
@@ -268,41 +268,32 @@ export interface IMessageReport {
   total: number;
 }
 
-export interface ITemplate {
+interface IAbstractTemplate {
   id?: string;
   name: string;
   locale: string;
   channel: string;
   category: string;
-  textReference?: string;
   components: IComponents;
   senderId: string;
   status?: TemplateStatus;
   notificationEmail?: string;
   comments?: IComment[];
-  suggestions?: ISuggestions[];
   createdAt?: string;
   updatedAt?: string;
 }
 
-export interface IResponseTemplate {
-  id?: string;
-  name: string;
-  locale: string;
-  channel: string;
-  category: string;
+export interface ITemplate extends IAbstractTemplate {
+  textReference?: string;
+  suggestions?: ISuggestions[];
+}
+
+export interface IResponseTemplate extends IAbstractTemplate {
   text: string;
-  components: IComponents;
   examples?: {
     [fieldName: string]: string;
   };
-  senderId: string;
   fields: string[];
-  status?: TemplateStatus;
-  notificationEmail?: string;
-  comments?: IComment[];
-  createdAt?: string;
-  updatedAt?: string;
 }
 
 export interface IPartialTemplate {

--- a/src/types/zenvia.ts
+++ b/src/types/zenvia.ts
@@ -268,32 +268,24 @@ export interface IMessageReport {
   total: number;
 }
 
-interface IAbstractTemplate {
+export interface ITemplate {
   id?: string;
   name: string;
   locale: string;
   channel: string;
+  senderId: string;
   category: string;
   components: IComponents;
-  senderId: string;
-  status?: TemplateStatus;
-  notificationEmail?: string;
-  comments?: IComment[];
-  createdAt?: string;
-  updatedAt?: string;
-}
-
-export interface ITemplate extends IAbstractTemplate {
-  textReference?: string;
-  suggestions?: ISuggestions[];
-}
-
-export interface IResponseTemplate extends IAbstractTemplate {
-  text: string;
   examples?: {
     [fieldName: string]: string;
   };
-  fields: string[];
+  notificationEmail?: string;
+  text?: string;
+  fields?: string[];
+  status?: TemplateStatus;
+  comments?: IComment[];
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface IPartialTemplate {
@@ -340,9 +332,7 @@ export interface IComponents {
 export interface IButtonsItems {
   type: string;
   text: string;
-  url?: string;
-  phoneNumber?: string;
-  payload?: string;
+  url: string;
 }
 
 export interface IChannels {

--- a/src/types/zenvia.ts
+++ b/src/types/zenvia.ts
@@ -281,7 +281,6 @@ export interface ITemplate {
   notificationEmail?: string;
   comments?: IComment[];
   suggestions?: ISuggestions[];
-  channels?: IChannels[];
   createdAt?: string;
   updatedAt?: string;
 }

--- a/src/types/zenvia.ts
+++ b/src/types/zenvia.ts
@@ -285,6 +285,26 @@ export interface ITemplate {
   updatedAt?: string;
 }
 
+export interface IResponseTemplate {
+  id?: string;
+  name: string;
+  locale: string;
+  channel: string;
+  category: string;
+  text: string;
+  components: IComponents;
+  examples?: {
+    [fieldName: string]: string;
+  };
+  senderId: string;
+  fields: string[];
+  status?: TemplateStatus;
+  notificationEmail?: string;
+  comments?: IComment[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 export interface IPartialTemplate {
   components?: IComponents;
   notificationEmail?: string;

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -727,7 +727,7 @@ describe('Client', () => {
         };
 
         const expected = /^----------------------------[0-9]{24}\r\nContent-Disposition: form-data; name="batch"\r\nContent-Type: application\/json\r\n\r\n{"name":"SOME_BATCH","channel":"sms","message":{"from":"FROM","contents":\[{"type":"text","text":"some text message"}\]},"columnMapper":{"recipient_header_name":"recipient_number_column","name":"recipient_name_column","protocol":"protocol_column"}}\r\n----------------------------[0-9]{24}\r\nContent-Disposition: form-data; name="contacts"; filename="file\.csv"\r\nContent-Type: text\/csv\r\n\r\ntelefone\n5511999999999\r\n----------------------------[0-9]{24}--\r\n$/m;
-        
+
         const zenviaNock = nock('https://api.zenvia.com')
         .post('/v2/message-batches', expected)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
@@ -781,7 +781,7 @@ describe('Client', () => {
         };
 
         const expected = /^----------------------------[0-9]{24}\r\nContent-Disposition: form-data; name="batch"\r\nContent-Type: application\/json\r\n\r\n{"name":"SOME_BATCH","channel":"sms","message":{"from":"FROM","contents":\[{"type":"text","text":"some text message"}\]},"columnMapper":{"recipient_header_name":"recipient_number_column","name":"recipient_name_column","protocol":"protocol_column"}}\r\n----------------------------[0-9]{24}\r\nContent-Disposition: form-data; name="contacts"; filename="contacts\.csv"\r\nContent-Type: text\/csv\r\n\r\ntelefone\n5511999999999\r\n----------------------------[0-9]{24}--\r\n$/m;
-        
+
         const zenviaNock = nock('https://api.zenvia.com')
         .post('/v2/message-batches', expected)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
@@ -945,7 +945,7 @@ describe('Client', () => {
         };
 
         const expected = /^----------------------------[0-9]{24}\r\nContent-Disposition: form-data; name="batch"\r\nContent-Type: application\/json\r\n\r\n{"name":"SOME_BATCH","channel":"whatsapp","message":{"from":"FROM","contents":\[{"type":"template","templateId":"a whatsapp template id"}\]},"columnMapper":{"recipient_header_name":"recipient_number_column","name":"recipient_name_column","protocol":"protocol_column"}}\r\n----------------------------[0-9]{24}\r\nContent-Disposition: form-data; name="contacts"; filename="file\.csv"\r\nContent-Type: text\/csv\r\n\r\ntelefone\n5511999999999\r\n----------------------------[0-9]{24}--\r\n$/m;
-        
+
         const zenviaNock = nock('https://api.zenvia.com')
         .post('/v2/message-batches', expected)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
@@ -999,7 +999,7 @@ describe('Client', () => {
         };
 
         const expected = /^----------------------------[0-9]{24}\r\nContent-Disposition: form-data; name="batch"\r\nContent-Type: application\/json\r\n\r\n{"name":"SOME_BATCH","channel":"whatsapp","message":{"from":"FROM","contents":\[{"type":"template","templateId":"a whatsapp template id"}\]},"columnMapper":{"recipient_header_name":"recipient_number_column","name":"recipient_name_column","protocol":"protocol_column"}}\r\n----------------------------[0-9]{24}\r\nContent-Disposition: form-data; name="contacts"; filename="contacts\.csv"\r\nContent-Type: text\/csv\r\n\r\ntelefone\n5511999999999\r\n----------------------------[0-9]{24}--\r\n$/m;
-        
+
         const zenviaNock = nock('https://api.zenvia.com')
         .post('/v2/message-batches', expected)
         .matchHeader('X-API-Token', 'SOME_TOKEN')
@@ -1490,13 +1490,6 @@ describe('Client', () => {
         ],
         status: 'APPROVED',
         comments: [],
-        channels: [
-          {
-            type: 'WHATSAPP',
-            senderId: 'detailed-gasosaurus',
-            status: 'APPROVED',
-          },
-        ],
         createdAt: '2020-06-22T20:35:05.491Z',
         updatedAt: '2020-06-22T20:35:05.491Z',
       }];
@@ -1520,13 +1513,6 @@ describe('Client', () => {
         ],
         status: 'APPROVED',
         comments: [],
-        channels: [
-          {
-            type: 'whatsapp',
-            senderId: 'detailed-gasosaurus',
-            status: 'APPROVED',
-          },
-        ],
         createdAt: '2020-06-22T20:35:05.491Z',
         updatedAt: '2020-06-22T20:35:05.491Z',
       }];
@@ -1562,13 +1548,6 @@ describe('Client', () => {
         ],
         status: 'APPROVED',
         comments: [],
-        channels: [
-          {
-            type: 'WHATSAPP',
-            senderId: 'detailed-gasosaurus',
-            status: 'APPROVED',
-          },
-        ],
         createdAt: '2020-06-22T20:35:05.491Z',
         updatedAt: '2020-06-22T20:35:05.491Z',
       };
@@ -1592,13 +1571,6 @@ describe('Client', () => {
         ],
         status: 'APPROVED',
         comments: [],
-        channels: [
-          {
-            type: 'whatsapp',
-            senderId: 'detailed-gasosaurus',
-            status: 'APPROVED',
-          },
-        ],
         createdAt: '2020-06-22T20:35:05.491Z',
         updatedAt: '2020-06-22T20:35:05.491Z',
       };

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -2,7 +2,7 @@
 
 import * as nock from 'nock';
 import { Readable } from 'stream';
-import { IContent, Channel, Client, TextContent, TemplateContent, FileContent, ITemplate, IResponseTemplate, ContactsContent, LocationContent, MessageSubscription, MessageStatusSubscription, ISmsMessageBatch, SmsMessageBatch, IWhatsAppMessageBatch, WhatsAppMessageBatch } from '../../src';
+import { IContent, Channel, Client, TextContent, TemplateContent, FileContent, ITemplate, ContactsContent, LocationContent, MessageSubscription, MessageStatusSubscription, ISmsMessageBatch, SmsMessageBatch, IWhatsAppMessageBatch, WhatsAppMessageBatch } from '../../src';
 
 describe('Client', () => {
 
@@ -1470,30 +1470,8 @@ describe('Client', () => {
   describe('Templates', () => {
 
     it('should list templates', async () => {
-      const requestTemplates: IResponseTemplate[] = [{
-        name: 'Sandbox - Shipping Update',
-        locale: 'pt_BR',
-        channel: 'WHATSAPP',
-        category: 'SHIPPING_UPDATE',
-        text: '{{name}}, informamos que o seu produto {{productName}} foi enviado para a transportadora e tem previsão de chegada em {{deliveryDate}}.',
-        components: {
-          body: {
-            type: 'TEXT_TEMPLATE',
-            text: '{{name}}, informamos que o seu produto {{productName}} foi enviado para a transportadora e tem previsão de chegada em {{deliveryDate}}.'
-          },
-        },
-        senderId: 'detailed-gasosaurus',
-        fields: [
-          'name',
-          'productName',
-          'deliveryDate',
-        ],
-        status: 'APPROVED',
-        comments: [],
-        createdAt: '2020-06-22T20:35:05.491Z',
-        updatedAt: '2020-06-22T20:35:05.491Z',
-      }];
-      const responseTemplates: IResponseTemplate[] = [{
+      const responseTemplates: ITemplate[] = [{
+        id: 'SOME_ID',
         name: 'Sandbox - Shipping Update',
         locale: 'pt_BR',
         channel: 'WHATSAPP',
@@ -1519,7 +1497,7 @@ describe('Client', () => {
       const zenviaNock = nock('https://api.zenvia.com')
       .get('/v2/templates')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
-      .reply(200, requestTemplates);
+      .reply(200, responseTemplates);
 
       const client = new Client('SOME_TOKEN');
       const actualMessageResponse = await client.listTemplates();
@@ -1528,30 +1506,8 @@ describe('Client', () => {
     });
 
     it('should get template with id', async () => {
-      const requestTemplates: IResponseTemplate = {
-        name: 'Sandbox - Shipping Update',
-        locale: 'pt_BR',
-        channel: 'WHATSAPP',
-        category: 'SHIPPING_UPDATE',
-        text: '{{name}}, informamos que o seu produto {{productName}} foi enviado para a transportadora e tem previsão de chegada em {{deliveryDate}}.',
-        components: {
-          body: {
-            type: 'TEXT_TEMPLATE',
-            text: '{{name}}, informamos que o seu produto {{productName}} foi enviado para a transportadora e tem previsão de chegada em {{deliveryDate}}.'
-          },
-        },
-        senderId: 'detailed-gasosaurus',
-        fields: [
-          'name',
-          'productName',
-          'deliveryDate',
-        ],
-        status: 'APPROVED',
-        comments: [],
-        createdAt: '2020-06-22T20:35:05.491Z',
-        updatedAt: '2020-06-22T20:35:05.491Z',
-      };
-      const responseTemplates: IResponseTemplate = {
+      const responseTemplates: ITemplate = {
+        id: 'SOME_ID',
         name: 'Sandbox - Shipping Update',
         locale: 'pt_BR',
         channel: 'WHATSAPP',
@@ -1577,7 +1533,7 @@ describe('Client', () => {
       const zenviaNock = nock('https://api.zenvia.com')
       .get('/v2/templates/SOME_TEMPLATE_ID')
       .matchHeader('X-API-Token', 'SOME_TOKEN')
-      .reply(200, requestTemplates);
+      .reply(200, responseTemplates);
 
       const client = new Client('SOME_TOKEN');
       const actualMessageResponse = await client.getTemplate('SOME_TEMPLATE_ID');

--- a/test/lib/client.spec.ts
+++ b/test/lib/client.spec.ts
@@ -2,7 +2,7 @@
 
 import * as nock from 'nock';
 import { Readable } from 'stream';
-import { IContent, Channel, Client, TextContent, TemplateContent, FileContent, ITemplate, ContactsContent, LocationContent, MessageSubscription, MessageStatusSubscription, ISmsMessageBatch, SmsMessageBatch, IWhatsAppMessageBatch, WhatsAppMessageBatch } from '../../src';
+import { IContent, Channel, Client, TextContent, TemplateContent, FileContent, ITemplate, IResponseTemplate, ContactsContent, LocationContent, MessageSubscription, MessageStatusSubscription, ISmsMessageBatch, SmsMessageBatch, IWhatsAppMessageBatch, WhatsAppMessageBatch } from '../../src';
 
 describe('Client', () => {
 
@@ -1470,7 +1470,7 @@ describe('Client', () => {
   describe('Templates', () => {
 
     it('should list templates', async () => {
-      const requestTemplates = [{
+      const requestTemplates: IResponseTemplate[] = [{
         name: 'Sandbox - Shipping Update',
         locale: 'pt_BR',
         channel: 'WHATSAPP',
@@ -1493,7 +1493,7 @@ describe('Client', () => {
         createdAt: '2020-06-22T20:35:05.491Z',
         updatedAt: '2020-06-22T20:35:05.491Z',
       }];
-      const responseTemplates = [{
+      const responseTemplates: IResponseTemplate[] = [{
         name: 'Sandbox - Shipping Update',
         locale: 'pt_BR',
         channel: 'WHATSAPP',
@@ -1528,7 +1528,7 @@ describe('Client', () => {
     });
 
     it('should get template with id', async () => {
-      const requestTemplates = {
+      const requestTemplates: IResponseTemplate = {
         name: 'Sandbox - Shipping Update',
         locale: 'pt_BR',
         channel: 'WHATSAPP',
@@ -1551,7 +1551,7 @@ describe('Client', () => {
         createdAt: '2020-06-22T20:35:05.491Z',
         updatedAt: '2020-06-22T20:35:05.491Z',
       };
-      const responseTemplates = {
+      const responseTemplates: IResponseTemplate = {
         name: 'Sandbox - Shipping Update',
         locale: 'pt_BR',
         channel: 'WHATSAPP',


### PR DESCRIPTION
Jira Link => https://zenvia.atlassian.net/browse/CON-318?atlOrigin=eyJpIjoiNDhmNWNlMGI4OWRiNDViNzg5NGM1NGYyODQ5ZTRiZTEiLCJwIjoiaiJ9

**Problem**

`getTemplate()` and `listTemplate()` functions were non-functional.
This hindered this SDK's user to list all their templates or a single template associated with a specific token registered on their Zenvia account. 

**Diagnostics**

The `.forEach()` functions in line 162 and 180 (before pull request) were iterating over a supposed array identified by the key `channels` inside the response from GET requests on `templates/` and `templates/:templateId`.
It is possible that at some point in time the `channels` key and its respective values were contained in the response for this request. If so, no longer.

**Implementation**

To correct the problem, the request for `getTemplate()` and `listTemplate()` will now come as they should: unedited after they are received from the Zenvia API, but typed correctly.
The tests were also fixed accordingly.